### PR TITLE
fix(diff): switch from `SetNestedAttribute` to `MapNestedAttribute` to resolve diff issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,4 @@ BREAKING CHANGES:
 - `fastly_service_vcl`: 
   - `active_version` renamed to `last_active`
   - `cloned_version` renamed to `version`
-  - `domain` renamed to `domains` and is now a nested attribute.
+  - `domain` renamed to `domains` and is now a nested attribute of a 'map' type.

--- a/docs/resources/fastly_service_vcl.md
+++ b/docs/resources/fastly_service_vcl.md
@@ -20,7 +20,7 @@ The Service resource requires a domain name configured to direct traffic to the 
 
 ### Required
 
-- `domains` (Attributes Set) (see [below for nested schema](#nestedatt--domains))
+- `domains` (Attributes Map) Each key within the map should be a domain that this service will respond to. It is important to note that changing this attribute will delete and recreate the resource (see [below for nested schema](#nestedatt--domains))
 - `name` (String) The unique name for the service to create
 
 ### Optional
@@ -43,16 +43,8 @@ The Service resource requires a domain name configured to direct traffic to the 
 <a id="nestedatt--domains"></a>
 ### Nested Schema for `domains`
 
-Required:
-
-- `name` (String) The domain that this service will respond to. It is important to note that changing this attribute will delete and recreate the resource
-
 Optional:
 
 - `comment` (String) An optional comment about the domain
-
-Read-Only:
-
-- `id` (String) Unique identifier used by the provider to determine changes within a nested set type
 
 

--- a/internal/provider/interfaces/resource.go
+++ b/internal/provider/interfaces/resource.go
@@ -46,8 +46,6 @@ type Resource interface {
 		api helpers.API,
 		serviceData *data.Service,
 	) error
-	// HasChanges indicates if the nested resource contains configuration changes.
-	HasChanges() bool
 	// InspectChanges checks for configuration changes and persists to data model.
 	InspectChanges(
 		ctx context.Context,
@@ -56,4 +54,6 @@ type Resource interface {
 		api helpers.API,
 		serviceData *data.Service,
 	) (bool, error)
+	// HasChanges indicates if the nested resource contains configuration changes.
+	HasChanges() bool
 }

--- a/internal/provider/models/domain.go
+++ b/internal/provider/models/domain.go
@@ -4,12 +4,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// Domain is a nested set attribute for the domain(s) associated with a service.
+// Domain is a nested map attribute for the domain(s) associated with a service.
+//
+// NOTE: The domain 'name' is the map key (see ../schemas/service.go)
 type Domain struct {
 	// Comment is an optional comment about the domain.
 	Comment types.String `tfsdk:"comment"`
-	// ID is a unique identifier used by the provider to determine changes within a nested set type.
-	ID types.String `tfsdk:"id"`
-	// Name is the domain that this service will respond to. It is important to note that changing this attribute will delete and recreate the resource.
-	Name types.String `tfsdk:"name"`
 }

--- a/internal/provider/models/service_vcl.go
+++ b/internal/provider/models/service_vcl.go
@@ -14,8 +14,8 @@ type ServiceVCL struct {
 	DefaultHost types.String `tfsdk:"default_host"`
 	// DefaultTTL is the default time-to-live (TTL) for the version.
 	DefaultTTL types.Int64 `tfsdk:"default_ttl"`
-	// Domains is a nested set attribute for the domain(s) associated with the service.
-	Domains []Domain `tfsdk:"domains"`
+	// Domains is a nested map attribute for the domain(s) associated with the service.
+	Domains map[string]Domain `tfsdk:"domains"`
 	// ForceDestroy ensures a service will be fully deleted upon `terraform destroy`.
 	ForceDestroy types.Bool `tfsdk:"force_destroy"`
 	// ID is a unique ID for the service.

--- a/internal/provider/resources/domain.go
+++ b/internal/provider/resources/domain.go
@@ -290,7 +290,7 @@ func read(
 		}
 
 		// NOTE: It's highly unlikely a domain would have no name.
-		// But I'd rather be safe than sorry and try to set a map key to "".
+		// But safer to just avoid accidentally setting a map key to an empty string.
 		if remoteDomainName == "" {
 			tflog.Trace(ctx, "Fastly API error", map[string]any{"http_resp": httpResp})
 			resp.Diagnostics.AddError("API Error", "No domain name set in API response")

--- a/internal/provider/resources/domain.go
+++ b/internal/provider/resources/domain.go
@@ -68,7 +68,6 @@ func (r *DomainResource) Read(
 	serviceData *data.Service,
 ) error {
 	var domains map[string]models.Domain
-	// TODO: Do we need to take address of map when getting/setting attributes?
 	req.State.GetAttribute(ctx, path.Root("domains"), &domains)
 
 	remoteDomains, err := read(ctx, domains, api, serviceData, resp)
@@ -174,10 +173,6 @@ func create(
 ) error {
 	createErr := errors.New("failed to create domain resource")
 
-	// TODO: Check if the version we have is correct.
-	// e.g. should it be latest 'active' or just latest version?
-	// It should depend on `activate` field but also whether the service pre-exists.
-	// The service might exist if it was imported or a secondary config run.
 	clientReq := api.Client.DomainAPI.CreateDomain(
 		api.ClientCtx,
 		service.ID,

--- a/internal/provider/schemas/service.go
+++ b/internal/provider/schemas/service.go
@@ -28,21 +28,14 @@ func Service() map[string]schema.Attribute {
 				helpers.StringDefaultModifier{Default: "Managed by Terraform"},
 			},
 		},
-		"domains": schema.SetNestedAttribute{
-			Required: true,
+		"domains": schema.MapNestedAttribute{
+			MarkdownDescription: "Each key within the map should be a domain that this service will respond to. It is important to note that changing this attribute will delete and recreate the resource",
+			Required:            true,
 			NestedObject: schema.NestedAttributeObject{
 				Attributes: map[string]schema.Attribute{
 					"comment": schema.StringAttribute{
 						MarkdownDescription: "An optional comment about the domain",
 						Optional:            true,
-					},
-					"id": schema.StringAttribute{
-						Computed:            true,
-						MarkdownDescription: "Unique identifier used by the provider to determine changes within a nested set type",
-					},
-					"name": schema.StringAttribute{
-						MarkdownDescription: "The domain that this service will respond to. It is important to note that changing this attribute will delete and recreate the resource",
-						Required:            true,
 					},
 				},
 			},

--- a/internal/provider/service_vcl_test.go
+++ b/internal/provider/service_vcl_test.go
@@ -76,7 +76,7 @@ func TestAccResourceServiceVCL(t *testing.T) {
 				Config: configCreate,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("fastly_service_vcl.test", "force_destroy", "false"),
-					// resource.TestCheckResourceAttr("fastly_service_vcl.test", "domains.#", "2"),
+					resource.TestCheckResourceAttr("fastly_service_vcl.test", "domains.%", "2"),
 				),
 			},
 			// Update and Read testing

--- a/internal/provider/service_vcl_test.go
+++ b/internal/provider/service_vcl_test.go
@@ -40,14 +40,10 @@ func TestAccResourceServiceVCL(t *testing.T) {
       name = "%s"
       force_destroy = %t
 
-      domains = [
-        {
-          name = "%s-tpff-1.integralist.co.uk"
-        },
-        {
-          name = "%s-tpff-2.integralist.co.uk"
-        },
-      ]
+      domains = {
+        "%s-tpff-1.integralist.co.uk" = {},
+        "%s-tpff-2.integralist.co.uk" = {},
+      }
     }
     `, serviceName, false, domainName, domainName)
 
@@ -62,15 +58,12 @@ func TestAccResourceServiceVCL(t *testing.T) {
       name = "%s"
       force_destroy = %t
 
-      domains = [
-        {
-          name = "%s-tpff-2-updated.integralist.co.uk"
-        },
-        {
+      domains = {
+        "%s-tpff-2-updated.integralist.co.uk" = {},
+        "%s-tpff-1.integralist.co.uk" = {
           comment = "a random updated comment"
-          name = "%s-tpff-1.integralist.co.uk"
         },
-      ]
+      }
     }
     `, serviceName, true, domainName+"-updated", domainName)
 
@@ -83,7 +76,7 @@ func TestAccResourceServiceVCL(t *testing.T) {
 				Config: configCreate,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("fastly_service_vcl.test", "force_destroy", "false"),
-					resource.TestCheckResourceAttr("fastly_service_vcl.test", "domains.#", "2"),
+					// resource.TestCheckResourceAttr("fastly_service_vcl.test", "domains.#", "2"),
 				),
 			},
 			// Update and Read testing

--- a/scripts/local-build.sh
+++ b/scripts/local-build.sh
@@ -23,8 +23,9 @@ EXAMPLE:
 terraform {
   required_providers {
     fastly = {
-      # The compiled binary name has the format `terraform-provider-<NAME>`
-      # So the 'fastly-framework' aligns with this pattern.
+      # The compiled binary name is `terraform-provider-fastly-framework`.
+      # The name has the format `terraform-provider-<NAME>`
+      # So the 'fastly-framework' in the source below aligns with this pattern.
       source = "integralist/fastly-framework"
     }
   }

--- a/scripts/local-build.sh
+++ b/scripts/local-build.sh
@@ -23,9 +23,20 @@ EXAMPLE:
 terraform {
   required_providers {
     fastly = {
-      # The compiled binary name is `terraform-provider-fastly-framework`.
-      # The name has the format `terraform-provider-<NAME>`
-      # So the 'fastly-framework' in the source below aligns with this pattern.
+      # Terraform uses the following pattern to identify a provider:
+      # terraform-provider-<NAME>
+      #
+      # When specifying a provider as a dependency the 'source' must contain the
+      # username and the provider name:
+      # source = "<USERNAME>/<PROVIDER_NAME>"
+      #
+      # This aligns with the Terraform registry URL:
+      # https://registry.terraform.io/providers/<USERNAME>/<PROVIDER_NAME>
+      #
+      # Our provider name is 'fastly-framework'.
+      # So the Terraform CLI looks for a binary ending with 'fastly-framework'.
+      # We compile a binary named `terraform-provider-fastly-framework`.
+      # Hence Terraform CLI knows to use that binary.
       source = "integralist/fastly-framework"
     }
   }


### PR DESCRIPTION
## Problem

The original design for 'domains' used a nested attribute of a Set type (similar to the original Terraform provider) and this causes Terraform to generate inaccurate diffs. 

An example of this can be seen in the below screenshot. I had two domains already in my state, the first domain was updated to have a comment, and the second domain had its name changed slightly. The generated diff correctly shows the second domain as needing to be deleted and a new domain with `-updated` in its name needing to be created BUT the first domain is _incorrectly_ showing as needing to be deleted and recreated (which isn't what is actually happening as internally we make a single 'update' API call to add the comment to the existing domain resource):

<img width="747" alt="Screenshot 2023-01-24 at 17 30 16" src="https://user-images.githubusercontent.com/180050/214394000-01428012-3a3d-467b-82e5-e1b0aa7de678.png">

## Solution
I'm switching to a nested _map_ attribute type, and although more verbose (for the user) in Terraform config syntax, the change actually helps simplify a bunch of domain logic (such as not having to manually identify a 'key' to be calculated into a hash, which in the case of the domain resource was its name field, and now that 'key' is automatically handled simply by the nature of the design of a map type). 

**Here is my initial plan:**

<img width="553" alt="Screenshot 2023-01-25 at 10 16 33" src="https://user-images.githubusercontent.com/180050/214537539-ff8bf0ff-233a-455c-965d-ea1cd9a0fd54.png">

**Here is the plan after making modifications:**

<img width="1054" alt="Screenshot 2023-01-25 at 10 19 02" src="https://user-images.githubusercontent.com/180050/214537914-f67ae2d1-e872-4c50-8adc-629315a6f2aa.png">

Notice how the generated diff is more accurate. It can recognise that a single field (comment in this case) is being modified 'in-place' and so we're not showing the first domain as needing to be deleted and recreated but simply needing to be modified.

## Extra

This change also makes _abstracting_ the algorithm used for calculating changes easier. Meaning, we should be able to make a function that can abstract this logic so it can be reused across different resource types (e.g. backends).

## Interface Changes

We're moving from config that looks like this (`SetNestedAttribute`):

```terraform
domains = [
    {
        name = "example-1.integralist.co.uk"
        comment = "a comment"
    },
    {
        name = "example-2.integralist.co.uk"
    },
]
```

To config that looks like this (`MapNestedAttribute`):

```terraform
domains = {
    "example-1.integralist.co.uk" = {
        comment = "a comment"
    },
    "example-2.integralist.co.uk" = {},
}
```