### PR TITLE
fix(resource/domain): change interface

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,6 +2,15 @@
 
 The latest [HashiCorp Terraform Plugin Framework](https://developer.hashicorp.com/terraform/plugin/framework) presents challenges that we should investigate and find more elegant solutions for.
 
+## CRUD boundaries
+
+Terraform doesn't have a concept of 'nested' resources, and so to workaround that design constraint our CRUD methods start to blur their boundary lines.
+
+- *CREATE:* Runs once for top-level and nested resources.
+- *READ:* Runs every time for top-level and nested resources.
+- *UPDATE:* Runs every time for top-level and nested resource + CREATE/DELETE for nested resources.
+- *DELETE:* Runs every time for top-level resources.
+
 ## Handling errors with nested attributes.
 
 With the original Fastly Terraform provider we had [this issue](https://github.com/fastly/terraform-provider-fastly/issues/631) related to the design of the provider using set 'blocks' to represent a nested resource (even though Terraform has no concept of a nested resource and expects a resource to be a 1:1 mapping with a single API endpoint).

--- a/docs/resources/fastly_service_vcl.md
+++ b/docs/resources/fastly_service_vcl.md
@@ -20,7 +20,7 @@ The Service resource requires a domain name configured to direct traffic to the 
 
 ### Required
 
-- `domains` (Attributes Map) Each key within the map should be a domain that this service will respond to. It is important to note that changing this attribute will delete and recreate the resource (see [below for nested schema](#nestedatt--domains))
+- `domains` (Attributes Map) Each key within the map should be a unique identifier for the resources contained within (see [below for nested schema](#nestedatt--domains))
 - `name` (String) The unique name for the service to create
 
 ### Optional
@@ -42,6 +42,10 @@ The Service resource requires a domain name configured to direct traffic to the 
 
 <a id="nestedatt--domains"></a>
 ### Nested Schema for `domains`
+
+Required:
+
+- `name` (String) The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the resource.
 
 Optional:
 

--- a/docs/resources/fastly_service_vcl.md
+++ b/docs/resources/fastly_service_vcl.md
@@ -20,7 +20,7 @@ The Service resource requires a domain name configured to direct traffic to the 
 
 ### Required
 
-- `domains` (Attributes Map) Each key within the map should be a unique identifier for the resources contained within (see [below for nested schema](#nestedatt--domains))
+- `domains` (Attributes Map) Each key within the map should be a unique identifier for the resources contained within. It is important to note that changing the key will delete and recreate the resource (see [below for nested schema](#nestedatt--domains))
 - `name` (String) The unique name for the service to create
 
 ### Optional
@@ -45,7 +45,7 @@ The Service resource requires a domain name configured to direct traffic to the 
 
 Required:
 
-- `name` (String) The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the resource.
+- `name` (String) The domain that this Service will respond to
 
 Optional:
 

--- a/internal/provider/models/domain.go
+++ b/internal/provider/models/domain.go
@@ -5,9 +5,11 @@ import (
 )
 
 // Domain is a nested map attribute for the domain(s) associated with a service.
-//
-// NOTE: The domain 'name' is the map key (see ../schemas/service.go)
 type Domain struct {
 	// Comment is an optional comment about the domain.
 	Comment types.String `tfsdk:"comment"`
+	// Name is a required field representing the domain name.
+	Name types.String `tfsdk:"name"`
+	// NamePast is internally used for tracking changes.
+	NamePast types.String `tfsdk:"-"`
 }

--- a/internal/provider/resources/domain/create.go
+++ b/internal/provider/resources/domain/create.go
@@ -27,8 +27,8 @@ func (r *Resource) Create(
 	var domains map[string]models.Domain
 	req.Plan.GetAttribute(ctx, path.Root("domains"), &domains)
 
-	for domainName, domainData := range domains {
-		if err := create(ctx, domainName, domainData, api, serviceData, resp); err != nil {
+	for _, domainData := range domains {
+		if err := create(ctx, domainData, api, serviceData, resp); err != nil {
 			return err
 		}
 	}
@@ -41,7 +41,6 @@ func (r *Resource) Create(
 // create is the common behaviour for creating this resource.
 func create(
 	ctx context.Context,
-	domainName string,
 	domainData models.Domain,
 	api helpers.API,
 	service *data.Service,
@@ -55,7 +54,7 @@ func create(
 		service.Version,
 	)
 
-	clientReq.Name(domainName)
+	clientReq.Name(domainData.Name.ValueString())
 
 	if !domainData.Comment.IsNull() {
 		clientReq.Comment(domainData.Comment.ValueString())

--- a/internal/provider/resources/domain/update.go
+++ b/internal/provider/resources/domain/update.go
@@ -35,20 +35,20 @@ func (r *Resource) Update(
 	// We should make them a single type (as the API is one endpoint).
 	// Then we can expose a `dynamic` boolean attribute to control the type.
 
-	for domainName := range r.Deleted {
-		if err := deleted(ctx, api, serviceData, domainName, resp); err != nil {
+	for _, domainData := range r.Deleted {
+		if err := deleted(ctx, api, serviceData, domainData, resp); err != nil {
 			return err
 		}
 	}
 
-	for domainName, domainData := range r.Added {
-		if err := added(ctx, api, serviceData, domainName, domainData, resp); err != nil {
+	for _, domainData := range r.Added {
+		if err := added(ctx, api, serviceData, domainData, resp); err != nil {
 			return err
 		}
 	}
 
-	for domainName, domainData := range r.Modified {
-		if err := modified(ctx, api, serviceData, domainName, domainData, resp); err != nil {
+	for _, domainData := range r.Modified {
+		if err := modified(ctx, api, serviceData, domainData, resp); err != nil {
 			return err
 		}
 	}
@@ -65,10 +65,10 @@ func deleted(
 	ctx context.Context,
 	api helpers.API,
 	serviceData *data.Service,
-	domainName string,
+	domainData models.Domain,
 	resp *resource.UpdateResponse,
 ) error {
-	clientReq := api.Client.DomainAPI.DeleteDomain(api.ClientCtx, serviceData.ID, serviceData.Version, domainName)
+	clientReq := api.Client.DomainAPI.DeleteDomain(api.ClientCtx, serviceData.ID, serviceData.Version, domainData.Name.ValueString())
 
 	_, httpResp, err := clientReq.Execute()
 	if err != nil {
@@ -89,12 +89,11 @@ func added(
 	ctx context.Context,
 	api helpers.API,
 	serviceData *data.Service,
-	domainName string,
 	domainData models.Domain,
 	resp *resource.UpdateResponse,
 ) error {
 	clientReq := api.Client.DomainAPI.CreateDomain(api.ClientCtx, serviceData.ID, serviceData.Version)
-	clientReq.Name(domainName)
+	clientReq.Name(domainData.Name.ValueString())
 
 	if !domainData.Comment.IsNull() {
 		clientReq.Comment(domainData.Comment.ValueString())
@@ -119,20 +118,21 @@ func modified(
 	ctx context.Context,
 	api helpers.API,
 	serviceData *data.Service,
-	domainName string,
 	domainData models.Domain,
 	resp *resource.UpdateResponse,
 ) error {
-	clientReq := api.Client.DomainAPI.UpdateDomain(api.ClientCtx, serviceData.ID, serviceData.Version, domainName)
+	domainNameParam := domainData.Name.ValueString()
+	namePast := domainData.NamePast.ValueString()
+	if namePast != "" {
+		domainNameParam = namePast
+	}
+	// TODO: Does NamePast need to be reset?
 
+	clientReq := api.Client.DomainAPI.UpdateDomain(api.ClientCtx, serviceData.ID, serviceData.Version, domainNameParam)
 	if !domainData.Comment.IsNull() {
 		clientReq.Comment(domainData.Comment.ValueString())
 	}
-
-	// NOTE: We don't bother to check/update the domain's Name field.
-	// This is because if the name of the domain has changed, then that means
-	// a new domain will be added and the original domain deleted. Thus, we'll
-	// only have a domain as 'modified' if the Comment field was modified.
+	clientReq.Name(domainData.Name.ValueString())
 
 	_, httpResp, err := clientReq.Execute()
 	if err != nil {

--- a/internal/provider/resources/domain/update.go
+++ b/internal/provider/resources/domain/update.go
@@ -126,7 +126,6 @@ func modified(
 	if namePast != "" {
 		domainNameParam = namePast
 	}
-	// TODO: Does NamePast need to be reset?
 
 	clientReq := api.Client.DomainAPI.UpdateDomain(api.ClientCtx, serviceData.ID, serviceData.Version, domainNameParam)
 	if !domainData.Comment.IsNull() {

--- a/internal/provider/schemas/service.go
+++ b/internal/provider/schemas/service.go
@@ -29,10 +29,14 @@ func Service() map[string]schema.Attribute {
 			},
 		},
 		"domains": schema.MapNestedAttribute{
-			MarkdownDescription: "Each key within the map should be a domain that this service will respond to. It is important to note that changing this attribute will delete and recreate the resource",
+			MarkdownDescription: "Each key within the map should be a unique identifier for the resources contained within",
 			Required:            true,
 			NestedObject: schema.NestedAttributeObject{
 				Attributes: map[string]schema.Attribute{
+					"name": schema.StringAttribute{
+						MarkdownDescription: "The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the resource.",
+						Required:            true,
+					},
 					"comment": schema.StringAttribute{
 						MarkdownDescription: "An optional comment about the domain",
 						Optional:            true,

--- a/internal/provider/schemas/service.go
+++ b/internal/provider/schemas/service.go
@@ -29,12 +29,12 @@ func Service() map[string]schema.Attribute {
 			},
 		},
 		"domains": schema.MapNestedAttribute{
-			MarkdownDescription: "Each key within the map should be a unique identifier for the resources contained within",
+			MarkdownDescription: "Each key within the map should be a unique identifier for the resources contained within. It is important to note that changing the key will delete and recreate the resource",
 			Required:            true,
 			NestedObject: schema.NestedAttributeObject{
 				Attributes: map[string]schema.Attribute{
 					"name": schema.StringAttribute{
-						MarkdownDescription: "The domain that this Service will respond to. It is important to note that changing this attribute will delete and recreate the resource.",
+						MarkdownDescription: "The domain that this Service will respond to",
 						Required:            true,
 					},
 					"comment": schema.StringAttribute{

--- a/internal/provider/service_vcl_test.go
+++ b/internal/provider/service_vcl_test.go
@@ -41,8 +41,12 @@ func TestAccResourceServiceVCL(t *testing.T) {
       force_destroy = %t
 
       domains = {
-        "%s-tpff-1.integralist.co.uk" = {},
-        "%s-tpff-2.integralist.co.uk" = {},
+        "example-1" = {
+          name = "%s-tpff-1.integralist.co.uk"
+        },
+        "example-2" = {
+          name = "%s-tpff-2.integralist.co.uk"
+        },
       }
     }
     `, serviceName, false, domainName, domainName)
@@ -51,7 +55,7 @@ func TestAccResourceServiceVCL(t *testing.T) {
 	// We also change the order of the domains so the second is now first.
 	// This should result in:
 	//    - One domain being "added"    (tpff-2-updated).
-	//    - One domain being "modified" (tpff-1).
+	//    - One domain being "modified" (tpff-1 has a comment added).
 	//    - One domain being "deleted"  (tpff-2).
 	configUpdate := fmt.Sprintf(`
     resource "fastly_service_vcl" "test" {
@@ -59,13 +63,16 @@ func TestAccResourceServiceVCL(t *testing.T) {
       force_destroy = %t
 
       domains = {
-        "%s-tpff-2-updated.integralist.co.uk" = {},
-        "%s-tpff-1.integralist.co.uk" = {
+        "example-2" = {
+          name = "%s-tpff-2-updated.integralist.co.uk"
+        },
+        "example-1" = {
+          name = "%s-tpff-1.integralist.co.uk"
           comment = "a random updated comment"
         },
       }
     }
-    `, serviceName, true, domainName+"-updated", domainName)
+    `, serviceName, true, domainName, domainName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -99,7 +106,7 @@ func TestAccResourceServiceVCL(t *testing.T) {
 				ResourceName:            "fastly_service_vcl.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"activate", "force_destroy", "reuse"},
+				ImportStateVerifyIgnore: []string{"activate", "domains", "force_destroy", "reuse"},
 			},
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/service_vcl_test.go
+++ b/internal/provider/service_vcl_test.go
@@ -102,6 +102,12 @@ func TestAccResourceServiceVCL(t *testing.T) {
 			// config and can't be imported. If we had this test before the 'update'
 			// test where we set `force` to `true`, then we'd use the last known state
 			// of `false` and that would prevent the delete operation from succeeding.
+			//
+			// NOTE: We have to ignore the dommains attribute when importing because
+			// of data type used (MapNestedAttribute). The map keys are arbitrarily
+			// chosen by a user in their config and so when importing a service we
+			// have to generate a uuid for the key, which doesn't match with the
+			// `example-<number>` key we've used in the earlier test config (above).
 			{
 				ResourceName:            "fastly_service_vcl.test",
 				ImportState:             true,

--- a/internal/provider/service_vcl_test.go
+++ b/internal/provider/service_vcl_test.go
@@ -54,9 +54,7 @@ func TestAccResourceServiceVCL(t *testing.T) {
 	// Update the first domain's comment + second domain's name (force_destroy = true).
 	// We also change the order of the domains so the second is now first.
 	// This should result in:
-	//    - One domain being "added"    (tpff-2-updated).
-	//    - One domain being "modified" (tpff-1 has a comment added).
-	//    - One domain being "deleted"  (tpff-2).
+	//    - Two domains being "modified"    (tpff-1 has a comment added + tpff-2 has changed name).
 	configUpdate := fmt.Sprintf(`
     resource "fastly_service_vcl" "test" {
       name = "%s"


### PR DESCRIPTION
**PROBLEM:**
The original schema interface for the `domains` nested attribute was a bit jarring, specifically when you only needed to define a domain and not a 'comment' for the domain (e.g. you'd have an empty `{}` block which just looked weird). 

Also, it made migrating from the prior version of the provider harder because a user wasn't just wrapping their existing block in a new type but they'd have to manually move things around and move the 'name' attribute out of the block and into a map key. This is even harder to do for users who automate the generation of their domains. 

**SOLUTION:**
Update the interface so the map key becomes arbitrarily selected by a user, and the domain 'name' is moved into its own attribute. This means we're changing from...

```tf
domains = {
    "example-1.integralist.co.uk" = {
        comment = "a comment"
    },
    "example-2.integralist.co.uk" = {}, // annoying empty block
}
```

...to this...

```tf
domains = {
  "example-1" = { // arbitrary name that must be unique
    name = "example-1.integralist.co.uk"
    comment = "a comment"
  },
  "example-2" = { // arbitrary name that must be unique
    name = "example-2.integralist.co.uk"
  },
}
```

Here's the initial plan output...

<img width="500" alt="Screenshot 2023-02-01 at 19 39 41" src="https://user-images.githubusercontent.com/180050/216146069-39cbba8c-59c7-4c43-af21-713e9830ae87.png">

Next, I add a comment to domain 1 and I update the 'name' of domain 2 (you can see from the following screenshot that we can a very clear diff presented)...

<img width="726" alt="Screenshot 2023-02-01 at 19 54 12" src="https://user-images.githubusercontent.com/180050/216149334-48249ad4-6b22-46ab-afab-059684498e59.png">

Next, I rename the 'example-2` key to 'testing-2' and the plan diff looks like this (notice that because the 'key' has changed the logic in the provider dictates that the new key must be a new domain while the old key is a deleted domain -- elsewhere in the provider we always make sure to delete a resource first before adding a resource to account for this scenario)...

<img width="560" alt="Screenshot 2023-02-01 at 19 59 27" src="https://user-images.githubusercontent.com/180050/216150506-293474cd-a084-4023-a2c5-6987049b9c08.png">

**NOTES:**
To get the test suite to pass I needed to ignore the `domains` attribute (see the test file for an explanation). Below is a screenshot otherwise showing how the "import validation" test fails if we don't ignore the attribute. Notice how when importing a service we've had to generate a uuid for the keys, whereas our prior test config had used `example-<number>`. 

This is unavoidable, but also, when importing a service it's expected for a user to have some manual steps to clean up the import stage as there usually is a misalignment when dealing with Fastly services.

<img width="1112" alt="Screenshot 2023-02-01 at 19 17 50" src="https://user-images.githubusercontent.com/180050/216141506-1ee339c2-4503-4e8d-82ff-19f79bf2bbad.png">

Additionally, I noticed that `terraform show` (after the initial `terraform apply`) wouldn't show the domains data...

<img width="467" alt="Screenshot 2023-02-01 at 19 42 27" src="https://user-images.githubusercontent.com/180050/216146534-767a0512-cb0d-4d29-8df2-f93466a6fac4.png">

It wasn't until I marshalled that data into json that it revealed they were marked as 'sensitive' data. It's unclear _why_ though.

```zsh
terraform show -json | jq '.values.root_module.resources' | jq '.[0].sensitive_values'
```

```json
{
  "domains": {
    "example-1": {},
    "example-2": {}
  }
}
```

I've raised a question on the HashiCorp discussion forums about this here:
https://discuss.hashicorp.com/t/why-is-mapnestedattribute-keys-showing-as-sensitive-values-in-state/49616